### PR TITLE
Reaction commentId null 허용

### DIFF
--- a/src/main/java/com/baseball_root/diary/domain/Reaction.java
+++ b/src/main/java/com/baseball_root/diary/domain/Reaction.java
@@ -18,10 +18,10 @@ public class Reaction {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    @Column(name = "diary_id")
+    @Column(name = "diary_id", nullable = true)
     private Long diaryId;
 
-    @Column(name = "comment_id")
+    @Column(name = "comment_id", nullable = true)
     private Long commentId;
 
     private boolean reactionType;


### PR DESCRIPTION
commentId가 null이면 게시물 좋아요, commentId가 존재하면 댓글 좋아요 로직에서 commentId가 null허용을 하지않아 발생했던 문제 수정